### PR TITLE
Fix: 발음 분석 passed 판정 시 길이 비교 오류 수정

### DIFF
--- a/app/services/pronunciation_service.py
+++ b/app/services/pronunciation_service.py
@@ -156,8 +156,15 @@ def evaluate_pronunciation_with_index(reference: str, user_text: str) -> Dict[st
         user_original_phs=user_original_phs
     )
 
-    filtered_user_phonemes = [ph for ph in user_phonemes if ph.strip() != ""]
-    filtered_correct_phonemes = [ph for ph in correct_phonemes if ph.strip() != ""]
+    filtered_user_phonemes = [
+        ph for ph in user_phonemes
+        if ph.strip() != "" and ph not in string.punctuation
+    ]
+
+    filtered_correct_phonemes = [
+        ph for ph in correct_phonemes
+        if ph.strip() != "" and ph not in string.punctuation
+    ]
 
     passed = (
         len(result["pronunciationErrors"]) == 0 and


### PR DESCRIPTION
## 주요 작업 내용

- `evaluate_pronunciation_with_index` 내 `filtered_user_phonemes`, `filtered_correct_phonemes` 모두에서 문장부호를 제거하도록 수정
- 사용자 발화와 정답 문장 간에 문장부호 차이로 인해 passed = false가 되던 문제 해결

## 기타 작업 내용

- 없음

## 코드 리뷰 포인트

- 없음
